### PR TITLE
fix: image padding high on smaller screens

### DIFF
--- a/layouts/partials/_inline_script.html
+++ b/layouts/partials/_inline_script.html
@@ -9,7 +9,7 @@
     showAnimationDuration: 300,
     hideAnimationDuration: 300,
     loop: false,
-    padding: { top: 20, bottom: 40, left: 100, right: 100 },
+    //padding: { top: 20, bottom: 40, left: 100, right: 100 },
     indexIndicatorSep: " of ",
 
     gallery: "#my-gallery",


### PR DESCRIPTION
Padding on the gallery image was too high on smaller screens (maybe cause photoswipe uses px).

So removed the padding.